### PR TITLE
Make installation of Squid frontend on Stratum 1 optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ variable | type | description
 `cvmfs_manage_firewall` | boolean | Attempt to configure firewalld (EL) or ufw (Debian) to permit traffic to configured ports. Default is `false`.
 `cvmfs_squid_conf_src` | path | Path to template Squid configuration file (for Stratum 1 and local proxy servers). Defaults are in the role `templates/` directory.
 `cvmfs_stratum0_http_ports` | list of integers | Port(s) to configure Apache on Stratum 0 servers to listen on. Default is `80`.
-`cvmfs_stratum1_http_ports` | list of integers | Port(s) to configure Squid on Stratum 1 servers to listen on. Default is `80` and `8000`.
-`cvmfs_stratum1_apache_port` | integer | Port to configure Apache on Stratum 1 servers to listen on. Default is `8008`.
+`cvmfs_stratum1_http_ports` | list of integers | Port(s) to configure Apache or Squid on Stratum 1 servers to listen on. Default is `80` and `8000`.
+`cvmfs_stratum1_apache_port_with_squid` | integer | Port to configure Apache on Stratum 1 servers to listen on when using a Squid frontend. Default is `8008`.
 `cvmfs_stratum1_cache_mem` | integer in MB | Amount of memory for Squid to use for caching. Default is `128`.
 `cvmfs_stratum1_cache_dir` | list of dicts |
 `cvmfs_localproxy_http_ports` | list of integers | Port(s) to configure Squid on local proxy servers to listen on.  Default is `3128`.

--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ variable | type | description
 `cvmfs_manage_firewall` | boolean | Attempt to configure firewalld (EL) or ufw (Debian) to permit traffic to configured ports. Default is `false`.
 `cvmfs_squid_conf_src` | path | Path to template Squid configuration file (for Stratum 1 and local proxy servers). Defaults are in the role `templates/` directory.
 `cvmfs_stratum0_http_ports` | list of integers | Port(s) to configure Apache on Stratum 0 servers to listen on. Default is `80`.
-`cvmfs_stratum1_http_ports` | list of integers | Port(s) to configure Apache or Squid on Stratum 1 servers to listen on. Default is `80` and `8000`.
+`cvmfs_stratum1_http_ports` | list of integers | Public port(s) to configure Apache or Squid on Stratum 1 servers to listen on. Default is `80` and `8000`.
 `cvmfs_stratum1_apache_port_with_squid` | integer | Port to configure Apache on Stratum 1 servers to listen on when using a Squid frontend. Default is `8008`.
+`cvmfs_stratum1_squid` | boolean | Install and configure a Squid frontend on Stratum 1 servers. Default is `false`.
 `cvmfs_stratum1_cache_mem` | integer in MB | Amount of memory for Squid to use for caching. Default is `128`.
 `cvmfs_stratum1_cache_dir` | list of dicts |
 `cvmfs_localproxy_http_ports` | list of integers | Port(s) to configure Squid on local proxy servers to listen on.  Default is `3128`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ cvmfs_stratum1_http_ports:
 cvmfs_localproxy_http_ports:
   - 3128
 
-cvmfs_stratum1_squid: no
+cvmfs_stratum1_squid: false
 # if a Squid frontend is used on the Stratum 1, Apache needs to listen on an internal port
 # otherwise we stick to cvmfs_stratum1_http_ports
 cvmfs_stratum1_apache_port_with_squid: 8008

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,10 @@ cvmfs_stratum1_http_ports:
 cvmfs_localproxy_http_ports:
   - 3128
 
-cvmfs_stratum1_apache_port: 8008
+cvmfs_stratum1_squid: no
+# if a Squid frontend is used on the Stratum 1, Apache needs to listen on an internal port
+# otherwise we stick to cvmfs_stratum1_http_ports
+cvmfs_stratum1_apache_port_with_squid: 8008
 cvmfs_stratum1_cache_mem: 128 # MB
 
 # Storage backend for Stratum 0/1 servers

--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -34,5 +34,5 @@
 
 - name: Install CernVM-FS packages and dependencies (apt)
   ansible.builtin.apt:
-    name: "{{ cvmfs_packages[_cvmfs_role] }}"
+    name: "{{ cvmfs_packages[_cvmfs_role] | reject('equalto', omit) | list }}"
     state: "{{ 'latest' if _cvmfs_upgrade else 'present' }}"

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -66,5 +66,5 @@
 
 - name: Install CernVM-FS packages and dependencies (yum)
   ansible.builtin.yum:
-    name: "{{ cvmfs_packages[_cvmfs_role] }}"
+    name: "{{ cvmfs_packages[_cvmfs_role] | reject('equalto', omit) | list }}"
     state: "{{ 'latest' if _cvmfs_upgrade else 'present' }}"

--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -8,13 +8,36 @@
 - name: Include key setup tasks
   ansible.builtin.include_tasks: keys.yml
 
-- name: Change Apache listen port
+- name: Disable Apache listen port in main config file
   ansible.builtin.lineinfile:
     dest: "{{ cvmfs_apache_conf_file }}"
-    line: Listen {{ cvmfs_stratum1_apache_port }}
     regexp: ^Listen\s+
+    state: absent
     backup: true
   when: cvmfs_config_apache
+  notify:
+    - Reload apache
+
+- name: Include Apache configuration file from conf.d directory
+  ansible.builtin.lineinfile:
+    dest: "{{ cvmfs_apache_conf_file }}"
+    line: "IncludeOptional {{ cvmfs_apache_conf_dir }}/*.conf"
+    state: present
+  notify:
+    - Reload apache
+
+- name: Make CVMFS-specific Apache configuration file
+  ansible.builtin.copy:
+    dest: "/{{ '/'.join(cvmfs_apache_conf_file.split('/')[1:3]) }}/{{ cvmfs_apache_conf_dir }}/cvmfs_ports.conf"
+    content: |
+        {% if cvmfs_stratum1_squid %}
+        Listen {{ cvmfs_stratum1_apache_port_with_squid }}
+        {% else %}
+        {% for port in cvmfs_stratum1_http_ports %}
+        Listen {{ port }}
+        {% endfor %}
+        {% endif %}
+    mode: 0644
   notify:
     - Reload apache
 
@@ -29,7 +52,7 @@
   ansible.builtin.include_tasks: squid.yml
   vars:
     _cvmfs_squid_conf_src: "{{ cvmfs_squid_conf_src | default('stratum1_squid.conf.j2') }}"
-  when: "cvmfs_storage == 'disk'"
+  when: cvmfs_storage == 'disk' and cvmfs_stratum1_squid
 
 - name: Include firewall tasks
   ansible.builtin.include_tasks: firewall.yml

--- a/templates/stratum1_squid.conf.j2
+++ b/templates/stratum1_squid.conf.j2
@@ -5,7 +5,7 @@
 http_port 80 accel
 http_port 3128 accel
 http_access allow all
-cache_peer 127.0.0.1 parent {{ cvmfs_stratum1_apache_port }} 0 no-query originserver
+cache_peer 127.0.0.1 parent {{ cvmfs_stratum1_apache_port_with_squid }} 0 no-query originserver
 
 {% if cvmfs_stratum1_cache_dir is defined %}
 cache_dir ufs {{ cvmfs_stratum1_cache_dir.dir }} {{ cvmfs_stratum1_cache_dir.size }} 16 256

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,6 +1,7 @@
 ---
 cvmfs_apache_service_name: apache2
 cvmfs_apache_conf_file: /etc/apache2/apache2.conf
+cvmfs_apache_conf_dir: conf-enabled
 
 cvmfs_squid_service_name: squid
 cvmfs_squid_conf_file: /etc/squid/squid.conf

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -19,7 +19,7 @@ cvmfs_packages:
     - cvmfs-server
     - cvmfs-config-default
     - libapache2-mod-wsgi-py3
-    - squid
+    - "{{ 'squid' if cvmfs_stratum1_squid else omit }}"
   stratum1-s3:
     - cvmfs-server
   localproxy:

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,6 +1,7 @@
 ---
 cvmfs_apache_service_name: httpd
 cvmfs_apache_conf_file: /etc/httpd/conf/httpd.conf
+cvmfs_apache_conf_dir: conf.d
 
 cvmfs_squid_service_name: squid
 cvmfs_squid_conf_file: /etc/squid/squid.conf

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -17,7 +17,7 @@ cvmfs_packages:
   stratum1-disk:
     - httpd
     - "{{ 'mod_wsgi' if ansible_distribution_major_version is version('8', '<') else 'python3-mod_wsgi' }}"
-    - squid
+    - "{{ 'squid' if cvmfs_stratum1_squid else omit }}"
     - cvmfs-server
     - cvmfs-config-default
   stratum1-s3:


### PR DESCRIPTION
Having a Squid frontend on a private Stratum 1 is rather useless, so I've made that optional (and disabled by default).