### PR TITLE
Allow overriding dnf repos

### DIFF
--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -18,48 +18,12 @@
     gpgcheck: true
     enabled: true
     protect: true
-  loop:
-    - name: cernvm
-      description: CernVM packages
-      baseurl: http://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
-    - name: cernvm-config
-      description: CernVM-FS extra config packages
-      baseurl: http://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
+  loop: "{{ cvmfs_dnf_repos }}"
 
 - name: Install CernVM yum key
   ansible.builtin.copy:
-    content: |
-      -----BEGIN PGP PUBLIC KEY BLOCK-----
-      Version: GnuPG v2.0.22 (GNU/Linux)
-
-      mQGiBEuGP6YRBADV89cbF4uoEX89Q8uxOklIDVJhOJAFKZ33LSdzHv3iObnjo5w4
-      wbb8FiSir4oWgarAco4u0kR1yKjHJ33oVB2xmPOzW3NWoHI7aPF7tCgo7FY9hNoC
-      4NEkNycvbfSoCScsv2yY5qz2q2sY1LWGZGbUXjBvKbmASe9sJFKJV7NsmwCg76W/
-      aMazleHyDtooD8tk3ZWvpKcD/Rg51Oad+ZLc7h45wDMHpaDvOBeGoyp+k7JgQd87
-      HfXiJtg/Q6zyTwrV3vCQvMpw3GRjRkZBcPgRWb6rUk68dL8fa2cTxhISX5/DIQzc
-      mmuDa0EgCGGAKUZ4bHqaexFFnp/B+VKBPvJuxLa0cBDd6eewxNwtHJ90EaMeBzGd
-      6zU2BADO9YbXiEMqRkfVLnuvD5G31/WJZvffXCxspnSfg923DbILWa4vNW9MLMsK
-      IVHvyVr0mZF8xdyQNVPUX3/4uahKM4hwuFqdbyjuLGEIF3U73aIJ0+YDep/+I6yU
-      JGHnxy8Ex+a1XIhJ1hSI7+oalSdt+w/pE3+2MQyUfSDPSXVA3LQ+Q2VyblZNIEFk
-      bWluaXN0cmF0b3IgKGN2bWFkbWluKSA8Y2VybnZtLmFkbWluaXN0cmF0b3JAY2Vy
-      bi5jaD6IXgQTEQIAHgIbAwYLCQgHAwIDFQIDAxYCAQIeAQIXgAUCVwOYkgAKCRAj
-      DTidiuRc50E1AJ9AYvH/cydD7029jxGcs8K87lo3jACdEhbCj3cjPsp2U/WfpgK1
-      BQOMiwe5Ag0ES4Y/qBAIAL3sWKXQKpbIOpwX+mNX2IV2XxNBM3KYjYOEii66i9ap
-      Po3BA39a9Wm9vh1kYIHTkh9Qqb8w53hc4ANkVT+cYzxXythGBjWoLtwCzKCPrIb7
-      RQJRc956Ot0q4qmlcUEGi5zefSIoJZR5jyR7rZS+1PNJYI05xY2+Eah1u9UxrlzB
-      H5DCsvUqTNK12WrPIibmLo8u+yIDJjwgh9O5YITC+et/g47NLfZdiAGPLEjvJFRi
-      7Ju+8ywO32dSVBPJQDktr5BC950DKZHA9n+sJ63iF3lP/aCTECpxxUqXVVqioobw
-      g5ytl60hw9I9sfwBP6z9PR90RcyT1l4giiBz9LV+KpcAAwUIAKeAxArGaJxzWziK
-      s7D8TTuE50Nw+S3RGhVzwSKy7183Z11iOEMqbm2/zwp65wFkntCKmLKDnGsTgFNp
-      stIyFwJmj34Axp7N3KGqXnTI+SIQd6VmzQ1phxfCOw8IGueOR6YI7S1GYWt7Dose
-      ZKz4EWdvXCOkQAhbxq/HT2c3ihxsuxrErxz7QtNaYOFXiuLj3mYH9XaMeEe8Pkl+
-      yyRTvyUNlMIu/i79qf+QUlsi10nCUm88cSXQiKWOJ4GiUoT+jD7pN4ohdALRVl0t
-      l/EyPTw+asG3lQhPZ+solvJXp+i7KF7nwnyXDB63WNH15S1pQLMnqCuGCFyegf6j
-      nOJU0AqISQQYEQIACQIbDAUCVwOYgwAKCRAjDTidiuRc534jAKDu/9BZU3rirEMr
-      DuGbmN3ulUM+UgCfe7lg5qrGXUzZlJFTnTaTgS3Z0Rg=
-      =fspm
-      -----END PGP PUBLIC KEY BLOCK-----
-    dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+    content: "{{ cvmfs_dnf_repo_key.content }}"
+    dest: "{{ cvmfs_dnf_repo_key.dest }}"
     owner: root
     group: root
     mode: "0644"

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -7,6 +7,48 @@ cvmfs_squid_conf_file: /etc/squid/squid.conf
 cvmfs_squid_user: squid
 cvmfs_squid_group: squid
 
+cvmfs_dnf_repos:
+  - name: cernvm
+    description: CernVM packages
+    baseurl: http://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
+  - name: cernvm-config
+    description: CernVM-FS extra config packages
+    baseurl: http://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
+
+cvmfs_dnf_repo_key:
+  content: |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v2.0.22 (GNU/Linux)
+
+    mQGiBEuGP6YRBADV89cbF4uoEX89Q8uxOklIDVJhOJAFKZ33LSdzHv3iObnjo5w4
+    wbb8FiSir4oWgarAco4u0kR1yKjHJ33oVB2xmPOzW3NWoHI7aPF7tCgo7FY9hNoC
+    4NEkNycvbfSoCScsv2yY5qz2q2sY1LWGZGbUXjBvKbmASe9sJFKJV7NsmwCg76W/
+    aMazleHyDtooD8tk3ZWvpKcD/Rg51Oad+ZLc7h45wDMHpaDvOBeGoyp+k7JgQd87
+    HfXiJtg/Q6zyTwrV3vCQvMpw3GRjRkZBcPgRWb6rUk68dL8fa2cTxhISX5/DIQzc
+    mmuDa0EgCGGAKUZ4bHqaexFFnp/B+VKBPvJuxLa0cBDd6eewxNwtHJ90EaMeBzGd
+    6zU2BADO9YbXiEMqRkfVLnuvD5G31/WJZvffXCxspnSfg923DbILWa4vNW9MLMsK
+    IVHvyVr0mZF8xdyQNVPUX3/4uahKM4hwuFqdbyjuLGEIF3U73aIJ0+YDep/+I6yU
+    JGHnxy8Ex+a1XIhJ1hSI7+oalSdt+w/pE3+2MQyUfSDPSXVA3LQ+Q2VyblZNIEFk
+    bWluaXN0cmF0b3IgKGN2bWFkbWluKSA8Y2VybnZtLmFkbWluaXN0cmF0b3JAY2Vy
+    bi5jaD6IXgQTEQIAHgIbAwYLCQgHAwIDFQIDAxYCAQIeAQIXgAUCVwOYkgAKCRAj
+    DTidiuRc50E1AJ9AYvH/cydD7029jxGcs8K87lo3jACdEhbCj3cjPsp2U/WfpgK1
+    BQOMiwe5Ag0ES4Y/qBAIAL3sWKXQKpbIOpwX+mNX2IV2XxNBM3KYjYOEii66i9ap
+    Po3BA39a9Wm9vh1kYIHTkh9Qqb8w53hc4ANkVT+cYzxXythGBjWoLtwCzKCPrIb7
+    RQJRc956Ot0q4qmlcUEGi5zefSIoJZR5jyR7rZS+1PNJYI05xY2+Eah1u9UxrlzB
+    H5DCsvUqTNK12WrPIibmLo8u+yIDJjwgh9O5YITC+et/g47NLfZdiAGPLEjvJFRi
+    7Ju+8ywO32dSVBPJQDktr5BC950DKZHA9n+sJ63iF3lP/aCTECpxxUqXVVqioobw
+    g5ytl60hw9I9sfwBP6z9PR90RcyT1l4giiBz9LV+KpcAAwUIAKeAxArGaJxzWziK
+    s7D8TTuE50Nw+S3RGhVzwSKy7183Z11iOEMqbm2/zwp65wFkntCKmLKDnGsTgFNp
+    stIyFwJmj34Axp7N3KGqXnTI+SIQd6VmzQ1phxfCOw8IGueOR6YI7S1GYWt7Dose
+    ZKz4EWdvXCOkQAhbxq/HT2c3ihxsuxrErxz7QtNaYOFXiuLj3mYH9XaMeEe8Pkl+
+    yyRTvyUNlMIu/i79qf+QUlsi10nCUm88cSXQiKWOJ4GiUoT+jD7pN4ohdALRVl0t
+    l/EyPTw+asG3lQhPZ+solvJXp+i7KF7nwnyXDB63WNH15S1pQLMnqCuGCFyegf6j
+    nOJU0AqISQQYEQIACQIbDAUCVwOYgwAKCRAjDTidiuRc534jAKDu/9BZU3rirEMr
+    DuGbmN3ulUM+UgCfe7lg5qrGXUzZlJFTnTaTgS3Z0Rg=
+    =fspm
+    -----END PGP PUBLIC KEY BLOCK-----
+  dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+
 cvmfs_packages:
   stratum0:
     - httpd


### PR DESCRIPTION
In our [use-case](https://github.com/stackhpc/ansible-slurm-appliance) we tend to use our own repo mirror for various reasons. This PR is a minimal change to allow overriding the default dnf repos. Default behaviour is unchanged.